### PR TITLE
Optimise install.sh and install AUR package if on Arch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,13 @@
-dir=$(pwd)
-cd /usr/local/bin/
-sudo curl -s https://raw.githubusercontent.com/jobcmax/maxfetch/main/maxfetch --output maxfetch
-sudo chmod +x /usr/local/bin/maxfetch
-echo "\033[1;34;48mmaxfetch is installed! \033[1;37;0m" 
+if [ -e /usr/bin/makepkg ]; then
+	printf "using AUR package\n"
+	pushd $(mktemp -d)
+	curl -s 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=maxfetch' -o PKGBUILD
+	makepkg -sci
+else
+	pushd /usr/local/bin
+	sudo curl -s https://raw.githubusercontent.com/jobcmax/maxfetch/main/maxfetch -o maxfetch
+	sudo chmod +x maxfetch
+fi
+popd
+printf "\033[1;34;48mmaxfetch is installed! \033[1;37;0m\n"
 maxfetch
-cd $dir


### PR DESCRIPTION
- `pushd` is like `cd`, but puts you back into your previous directory when you run `popd`
- `mktemp` creates a temporary directory in /tmp
- `printf` fixes a few problems that `echo` has; the `echo` man page says:
> NOTE: printf(1) is a preferred alternative, which does not have issues outputting option-like strings.
- also, it now checks if the user is on Arch, and if so, installs the AUR package instead of putting the script into /usr/local/bin.