### PR TITLE
Use nice nerd font glyph for colours instead of three squares

### DIFF
--- a/maxfetch
+++ b/maxfetch
@@ -1,5 +1,5 @@
 #!/bin/sh
-unicode="▅▅▅" 
+unicode=" " 
 version="1.2.0"
 
 _black=$(tput setaf 0)


### PR DESCRIPTION
The screenshot in the readme shows these symbols being used but the actual script doesn't use them :sob:

Before and after:

![Screenshot](https://i.ibb.co/4NYQrJ4/Untitled.png)
